### PR TITLE
Moving observation/action spaces into __init__ instead of task_start/end

### DIFF
--- a/examples/example_main.py
+++ b/examples/example_main.py
@@ -14,16 +14,11 @@ def main():
     logging.basicConfig(level=logging.INFO)
 
     env: gym.Env = gym.make("CartPole-v1")
-    agent: Agent = LoggingAgent()
+    agent: Agent = LoggingAgent(env.observation_space, env.action_space)
 
     agent.block_start(is_learning_allowed=True)
 
-    agent.task_start(
-        env.observation_space,
-        env.action_space,
-        task_name="CartPole",
-        variant_name="Default",
-    )
+    agent.task_start(task_name="CartPole", variant_name="Default")
 
     agent.episode_start()
 
@@ -35,12 +30,7 @@ def main():
 
     agent.episode_end()
 
-    agent.task_end(
-        env.observation_space,
-        env.action_space,
-        task_name="CartPole",
-        variant_name="Default",
-    )
+    agent.task_end(task_name="CartPole", variant_name="Default")
 
     agent.block_end(is_learning_allowed=True)
 

--- a/examples/logging_agent.py
+++ b/examples/logging_agent.py
@@ -7,8 +7,9 @@ logger = logging.getLogger(__name__)
 
 
 class LoggingAgent(Agent):
-    def __init__(self) -> None:
-        self.action_space = None
+    def __init__(self, observation_space: gym.Space, action_space: gym.Space) -> None:
+        super().__init__(observation_space, action_space)
+        logger.info(f"Constructed with {observation_space=} {action_space=}")
 
     def block_start(self, is_learning_allowed: bool) -> None:
         if is_learning_allowed:
@@ -18,16 +19,12 @@ class LoggingAgent(Agent):
 
     def task_start(
         self,
-        observation_space: gym.Space,
-        action_space: gym.Space,
         task_name: typing.Optional[str],
         variant_name: typing.Optional[str],
     ) -> None:
-        self.action_space = action_space
         logger.info(
-            f"\tAbout to start interacting with a new task. {observation_space=} {action_space=} {task_name=} {variant_name=}"
+            f"\tAbout to start interacting with a new task. {task_name=} {variant_name=}"
         )
-        self.action_space = action_space
 
     def episode_start(self) -> None:
         logger.info("\t\tAbout to start a new episode")
@@ -52,14 +49,10 @@ class LoggingAgent(Agent):
 
     def task_end(
         self,
-        observation_space: gym.Space,
-        action_space: gym.Space,
         task_name: typing.Optional[str],
         variant_name: typing.Optional[str],
     ) -> None:
-        logger.info(
-            f"\tDone interacting with task. {observation_space=} {action_space=} {task_name=} {variant_name=}"
-        )
+        logger.info(f"\tDone interacting with task. {task_name=} {variant_name=}")
 
     def block_end(self, is_learning_allowed: bool) -> None:
         if is_learning_allowed:

--- a/examples/simple_runner.py
+++ b/examples/simple_runner.py
@@ -12,17 +12,18 @@ def run_rl(
     for block in curriculum.blocks():
         agent.block_start(block.is_learning_allowed())
         for experience in block.experiences():
-            env = experience.info()
-            agent.task_start(env.observation_space, env.action_space, None, None)
-            for obs, action, reward, done, next_obs in experience.generate(agent.step):
+            agent.task_start(None, None)
+            for obs, action, reward, done, next_obs in experience.generate(
+                agent.step_observe
+            ):
                 if block.is_learning_allowed():
-                    keep_going = agent.step_result(obs, action, reward, done, next_obs)
+                    keep_going = agent.step_reward(obs, action, reward, done, next_obs)
                 else:
                     keep_going = True
                 if done:
                     agent.episode_end()
                 done = done or keep_going
-            agent.task_end(env.observation_space, env.action_space, None, None)
+            agent.task_end(None, None)
         agent.block_end(block.is_learning_allowed())
 
 
@@ -42,7 +43,8 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
 
+    env = gym.make("CartPole-v1")
+    agent = LoggingAgent(env.observation_space, env.action_space)
     curriculum = ExampleCurriculum()
-    agent = LoggingAgent()
 
     run_rl(agent, curriculum)

--- a/tella/agent.py
+++ b/tella/agent.py
@@ -34,6 +34,17 @@ class Agent(abc.ABC):
     The only requirement is to implement :meth:`Agent.step_observe()`.
     """
 
+    def __init__(self, observation_space: gym.Space, action_space: gym.Space) -> None:
+        """
+        The constructor for the Agent.
+
+        :param observation_space: The observation space from the :class:`gym.Env`.
+        :param action_space: The action space from the :class:`gym.Env`.
+        """
+        super().__init__()
+        self.observation_space = observation_space
+        self.action_space = action_space
+
     def block_start(self, is_learning_allowed: bool) -> None:
         """
         Signifies a new block (either learning or evaluation) is about to start.
@@ -47,8 +58,6 @@ class Agent(abc.ABC):
 
     def task_start(
         self,
-        observation_space: gym.Space,
-        action_space: gym.Space,
         task_name: typing.Optional[str],
         variant_name: typing.Optional[str],
     ) -> None:
@@ -58,8 +67,6 @@ class Agent(abc.ABC):
 
         The next method called would be :meth:`Agent.episode_start()`.
 
-        :param observation_space: The observation space from the :class:`gym.Env`.
-        :param action_space: The action space from the :class:`gym.Env`.
         :param task_name: An optional value indicating the name of the task
         :param variant_name: An optional value indicating the name of the task variant
         """
@@ -130,8 +137,6 @@ class Agent(abc.ABC):
 
     def task_end(
         self,
-        observation_space: gym.Space,
-        action_space: gym.Space,
         task_name: typing.Optional[str],
         variant_name: typing.Optional[str],
     ) -> None:
@@ -141,8 +146,6 @@ class Agent(abc.ABC):
         The next method called would be :meth:`Agent.task_start()` if there
         are more tasks in the block, otherwise :meth:`Agent.block_end()`.
 
-        :param observation_space: The observation space from the :class:`gym.Env`.
-        :param action_space: The action space from the :class:`gym.Env`.
         :param task_name: An optional value indicating the name of the task
         :param variant_name: An optional value indicating the name of the task variant
         """


### PR DESCRIPTION
This is due to the requirement that the observation & action spaces must be the same for an entire curriculum.