### PR TITLE
Replace 3.8+ f-string syntax for 3.7 compatibility.

### DIFF
--- a/examples/rl_dqn_agent.py
+++ b/examples/rl_dqn_agent.py
@@ -122,7 +122,8 @@ class MinimalRlDqnAgent(ContinualRLAgent):
             observation_space, action_space, num_envs, metric
         )
         logger.info(
-            f"Constructed with {observation_space=} {action_space=} {num_envs=}"
+            f"Constructed with observation_space={observation_space} "
+            f"action_space={action_space} num_envs={num_envs}"
         )
 
         self.q = Qnet()
@@ -145,7 +146,9 @@ class MinimalRlDqnAgent(ContinualRLAgent):
             self.training = False
 
     def task_start(self, task_name: typing.Optional[str]) -> None:
-        logger.info(f"\tAbout to start interacting with a new task. {task_name=}")
+        logger.info(
+            f"\tAbout to start interacting with a new task. task_name={task_name}"
+        )
 
     def consume_task_variant(self, task_variant: AbstractRLTaskVariant) -> Metrics:
         logger.info("\tConsuming task variant")
@@ -167,7 +170,7 @@ class MinimalRlDqnAgent(ContinualRLAgent):
     def step_transition(self, step: StepData):
         s, a, r, done, s_prime = step
         self.memory.put((s, a, r / 100.0, s_prime, 0.0 if done else 1.0))
-        logger.debug(f"\t\t\tReceived transition {done=}")
+        logger.debug(f"\t\t\tReceived transition done={done}")
 
         # Handle end-of-episode matters: training, logging, and annealing
         if done:
@@ -194,7 +197,7 @@ class MinimalRlDqnAgent(ContinualRLAgent):
             )  # Linear annealing from 8% to 1%
 
     def task_end(self, task_name: typing.Optional[str]) -> None:
-        logger.info(f"\tDone interacting with task. {task_name=}")
+        logger.info(f"\tDone interacting with task. task_name={task_name}")
 
     def block_end(self, is_learning_allowed: bool) -> None:
         if is_learning_allowed:

--- a/examples/rl_logging_agent.py
+++ b/examples/rl_logging_agent.py
@@ -18,7 +18,8 @@ class LoggingAgent(ContinualRLAgent):
     ) -> None:
         super().__init__(observation_space, action_space, num_envs)
         logger.info(
-            f"Constructed with {observation_space=} {action_space=} {num_envs=}"
+            f"Constructed with observation_space={observation_space} "
+            f"action_space={action_space} num_envs={num_envs}"
         )
 
     def block_start(self, is_learning_allowed: bool) -> None:
@@ -32,7 +33,9 @@ class LoggingAgent(ContinualRLAgent):
         self,
         task_name: typing.Optional[str],
     ) -> None:
-        logger.info(f"\tAbout to start interacting with a new task. {task_name=}")
+        logger.info(
+            f"\tAbout to start interacting with a new task. task_name={task_name}"
+        )
 
     def task_variant_start(
         self,
@@ -40,7 +43,8 @@ class LoggingAgent(ContinualRLAgent):
         variant_name: typing.Optional[str],
     ) -> None:
         logger.info(
-            f"\tAbout to start interacting with a new task variant. {task_name=} {variant_name=}"
+            f"\tAbout to start interacting with a new task variant. "
+            f"task_name={task_name} variant_name={variant_name}"
         )
 
     def consume_task_variant(self, task_variant: AbstractRLTaskVariant):
@@ -57,13 +61,13 @@ class LoggingAgent(ContinualRLAgent):
 
     def step_transition(self, step: StepData) -> None:
         obs, action, reward, done, next_obs = step
-        logger.info(f"\t\t\tReceived step {done=}")
+        logger.info(f"\t\t\tReceived step done={done}")
 
     def task_end(
         self,
         task_name: typing.Optional[str],
     ) -> None:
-        logger.info(f"\tDone interacting with task. {task_name=}")
+        logger.info(f"\tDone interacting with task. task_name={task_name}")
 
     def task_variant_end(
         self,
@@ -71,7 +75,8 @@ class LoggingAgent(ContinualRLAgent):
         variant_name: typing.Optional[str],
     ) -> None:
         logger.info(
-            f"\tDone interacting with task variant. {task_name=} {variant_name=}"
+            f"\tDone interacting with task variant. "
+            f"task_name={task_name} variant_name={variant_name}"
         )
 
     def block_end(self, is_learning_allowed: bool) -> None:


### PR DESCRIPTION
Resolves #68. Syntax was `f"{variable=}"` which is now reverted to `f"variable={variable}"`.