### PR TITLE
Closes #59 include API classes/functions in __init__.py

### DIFF
--- a/examples/rl_dqn_agent.py
+++ b/examples/rl_dqn_agent.py
@@ -12,17 +12,6 @@ import torch.nn.functional as F
 import torch.optim as optim
 
 import tella
-from tella.agents import (
-    Action,
-    ContinualRLAgent,
-    Observation,
-    Metrics,
-)
-from tella.metrics import RLMetricAccumulator
-from tella.curriculum import (
-    Transition,
-    AbstractRLTaskVariant,
-)
 
 
 logger = logging.getLogger("Example DQN Agent")
@@ -117,13 +106,13 @@ def train(q, q_target, memory, optimizer):
 
 
 # minimalRL writes DQN in a script, so translation here requires moving components into the agent class
-class MinimalRlDqnAgent(ContinualRLAgent):
+class MinimalRlDqnAgent(tella.ContinualRLAgent):
     def __init__(
         self,
         observation_space: gym.Space,
         action_space: gym.Space,
         num_envs: int,
-        metric: typing.Optional[RLMetricAccumulator] = None,
+        metric: typing.Optional[tella.RLMetricAccumulator] = None,
     ) -> None:
         super(MinimalRlDqnAgent, self).__init__(
             observation_space, action_space, num_envs, metric
@@ -178,13 +167,15 @@ class MinimalRlDqnAgent(ContinualRLAgent):
             f"task_name={task_name} variant_name={variant_name}"
         )
 
-    def learn_task_variant(self, task_variant: AbstractRLTaskVariant) -> Metrics:
+    def learn_task_variant(
+        self, task_variant: tella.AbstractRLTaskVariant
+    ) -> tella.Metrics:
         logger.info("\tConsuming task variant")
         return super().learn_task_variant(task_variant)
 
     def choose_action(
-        self, observations: typing.List[typing.Optional[Observation]]
-    ) -> typing.List[typing.Optional[Action]]:
+        self, observations: typing.List[typing.Optional[tella.Observation]]
+    ) -> typing.List[typing.Optional[tella.Action]]:
         logger.debug(f"\t\t\tReturn {len(observations)} actions")
         return [
             None
@@ -196,7 +187,7 @@ class MinimalRlDqnAgent(ContinualRLAgent):
             for obs in observations
         ]
 
-    def receive_transition(self, transition: Transition):
+    def receive_transition(self, transition: tella.Transition):
         s, a, r, done, s_prime = transition
         self.memory.put(
             (s.flatten(), a, r / 100.0, s_prime.flatten(), 0.0 if done else 1.0)

--- a/examples/rl_logging_agent.py
+++ b/examples/rl_logging_agent.py
@@ -3,18 +3,11 @@ import typing
 
 import gym
 import tella
-from tella.agents import ContinualRLAgent
-from tella.curriculum import (
-    Transition,
-    Observation,
-    Action,
-    AbstractRLTaskVariant,
-)
 
 logger = logging.getLogger("Example Logging Agent")
 
 
-class LoggingAgent(ContinualRLAgent):
+class LoggingAgent(tella.ContinualRLAgent):
     def __init__(
         self, observation_space: gym.Space, action_space: gym.Space, num_envs: int
     ) -> None:
@@ -49,19 +42,19 @@ class LoggingAgent(ContinualRLAgent):
             f"task_name={task_name} variant_name={variant_name}"
         )
 
-    def learn_task_variant(self, task_variant: AbstractRLTaskVariant):
+    def learn_task_variant(self, task_variant: tella.AbstractRLTaskVariant):
         logger.info("\tConsuming task variant")
         return super().learn_task_variant(task_variant)
 
     def choose_action(
-        self, observations: typing.List[typing.Optional[Observation]]
-    ) -> typing.List[typing.Optional[Action]]:
+        self, observations: typing.List[typing.Optional[tella.Observation]]
+    ) -> typing.List[typing.Optional[tella.Action]]:
         logger.debug(f"\t\t\tReturn {len(observations)} random actions")
         return [
             None if obs is None else self.action_space.sample() for obs in observations
         ]
 
-    def receive_transition(self, transition: Transition) -> None:
+    def receive_transition(self, transition: tella.Transition) -> None:
         obs, action, reward, done, next_obs = transition
         logger.debug(f"\t\t\tReceived transition done={done}")
 

--- a/examples/rl_minimal_agent.py
+++ b/examples/rl_minimal_agent.py
@@ -2,22 +2,20 @@ import logging
 import typing
 
 import tella
-from tella.curriculum import Transition
-from tella.agents import ContinualRLAgent, Observation, Action
 
 
 logger = logging.getLogger("Example Random Agent")
 
 
-class MinimalRandomAgent(ContinualRLAgent):
+class MinimalRandomAgent(tella.ContinualRLAgent):
     def choose_action(
-        self, observations: typing.List[typing.Optional[Observation]]
-    ) -> typing.List[typing.Optional[Action]]:
+        self, observations: typing.List[typing.Optional[tella.Observation]]
+    ) -> typing.List[typing.Optional[tella.Action]]:
         return [
             None if obs is None else self.action_space.sample() for obs in observations
         ]
 
-    def receive_transition(self, transition: Transition):
+    def receive_transition(self, transition: tella.Transition):
         pass
 
 

--- a/tella/__init__.py
+++ b/tella/__init__.py
@@ -19,7 +19,10 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
+from .agents import ContinualRLAgent, Metrics
 from .cli import rl_cli
+from .curriculum import AbstractRLTaskVariant, Action, Observation, Transition
+from .metrics import RLMetricAccumulator
 from ._curriculums import load_curriculum_registry
 
 load_curriculum_registry()  # NOTE: inserts things into curriculum_registry


### PR DESCRIPTION
This includes the expected public API components so that users should only need to import tella.

We'll need to update as we continue development.