### PR TITLE
cannot use "Test" as beginning of test object due to test discovery

### DIFF
--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -17,7 +17,7 @@ from tella.curriculum import (
 )
 
 
-class TestCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
+class SampleCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
     def __init__(
         self,
         blocks: typing.Iterable[
@@ -27,7 +27,7 @@ class TestCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
             ]
         ],
     ) -> None:
-        super(TestCurriculum, self).__init__(0)
+        super().__init__(0)
         self.blocks = blocks
 
     def learn_blocks_and_eval_blocks(
@@ -43,7 +43,7 @@ class TestCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
 
 
 def test_simple_block_task_split():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             simple_learn_block(
                 [
@@ -66,7 +66,7 @@ def test_simple_block_task_split():
 
 
 def test_generator_curriculum():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         simple_learn_block(
             EpisodicTaskVariant(
                 CartPoleEnv,
@@ -83,7 +83,7 @@ def test_generator_curriculum():
 
 
 def test_curriculum_summary():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             simple_learn_block(
                 [
@@ -236,7 +236,7 @@ def test_interleaved_rng_seed():
     assert first_call_tasks == second_call_tasks
 
 
-class TestInterleaved(InterleavedEvalCurriculum):
+class SampleInterleavedCurriculum(InterleavedEvalCurriculum):
     def learn_blocks(self) -> typing.Iterable[AbstractLearnBlock[TaskVariantType]]:
         yield simple_learn_block(
             [
@@ -284,7 +284,7 @@ class TestInterleaved(InterleavedEvalCurriculum):
 
 
 def test_interleaved_structure():
-    curriculum = TestInterleaved(0)
+    curriculum = SampleInterleavedCurriculum(0)
     blocks = list(curriculum.learn_blocks_and_eval_blocks())
 
     assert len(blocks) == 7

--- a/tests/test_curriculum_validation.py
+++ b/tests/test_curriculum_validation.py
@@ -17,7 +17,7 @@ from tella.curriculum import (
 )
 
 
-class TestCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
+class SampleCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
     def __init__(
         self,
         blocks: typing.Iterable[
@@ -27,7 +27,7 @@ class TestCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
             ]
         ],
     ) -> None:
-        super(TestCurriculum, self).__init__(0)
+        super().__init__(0)
         self.blocks = blocks
 
     def learn_blocks_and_eval_blocks(
@@ -43,7 +43,7 @@ class TestCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
 
 
 def test_correct_curriculum():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             simple_learn_block(
                 [
@@ -66,7 +66,7 @@ def test_correct_curriculum():
 
 
 def test_error_on_diff_task_labels():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             LearnBlock(
                 [
@@ -99,7 +99,7 @@ def test_error_on_diff_task_labels():
 
 
 def test_error_on_multiple_spaces():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             simple_learn_block(
                 [
@@ -126,7 +126,7 @@ def test_error_on_multiple_spaces():
 
 
 def test_warn_same_variant_labels():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             simple_learn_block(
                 [
@@ -150,7 +150,7 @@ def test_warn_same_variant_labels():
 
 
 def test_empty_curriculum():
-    curriculum = TestCurriculum([])
+    curriculum = SampleCurriculum([])
 
     with pytest.raises(ValueError) as err:
         validate_curriculum(curriculum)
@@ -159,7 +159,7 @@ def test_empty_curriculum():
 
 
 def test_empty_block():
-    curriculum = TestCurriculum([LearnBlock([])])
+    curriculum = SampleCurriculum([LearnBlock([])])
 
     with pytest.raises(ValueError) as err:
         validate_curriculum(curriculum)
@@ -168,7 +168,7 @@ def test_empty_block():
 
 
 def test_empty_task():
-    curriculum = TestCurriculum([LearnBlock([TaskBlock("Task1", [])])])
+    curriculum = SampleCurriculum([LearnBlock([TaskBlock("Task1", [])])])
 
     with pytest.raises(ValueError) as err:
         validate_curriculum(curriculum)
@@ -177,7 +177,7 @@ def test_empty_task():
 
 
 def test_invalid_task_params():
-    curriculum = TestCurriculum(
+    curriculum = SampleCurriculum(
         [
             simple_eval_block(
                 [EpisodicTaskVariant(CartPoleEnv, num_episodes=1, params={"a": 1})]


### PR DESCRIPTION
pytest searches for tests based on names and so was trying to treat TestCurriculum as a test class. This PR replaces that with "Sample" to avoid that confusion.