### PR TITLE
use raw literals in regular expressions to avoid invalid escaping

### DIFF
--- a/tests/test_curriculum_validation.py
+++ b/tests/test_curriculum_validation.py
@@ -219,7 +219,7 @@ def test_validate_invalid_params_function():
     with pytest.raises(ValueError) as err:
         validate_params(example_function, ["a", "b"])
 
-    assert err.match("Parameters not accepted: \['b'\]")
+    assert err.match(r"Parameters not accepted: \['b'\]")
 
 
 def test_validate_invalid_params_class():
@@ -230,7 +230,7 @@ def test_validate_invalid_params_class():
     with pytest.raises(ValueError) as err:
         validate_params(ExampleClass, ["a", "b"])
 
-    assert err.match("Parameters not accepted: \['b'\]")
+    assert err.match(r"Parameters not accepted: \['b'\]")
 
 
 def test_validate_missing_params_function():
@@ -240,12 +240,12 @@ def test_validate_missing_params_function():
     with pytest.raises(ValueError) as err:
         validate_params(example_function, [])
 
-    assert err.match("Missing parameters: \['a', 'b'\]")
+    assert err.match(r"Missing parameters: \['a', 'b'\]")
 
     with pytest.raises(ValueError) as err:
         validate_params(example_function, ["a"])
 
-    assert err.match("Missing parameters: \['b'\]")
+    assert err.match(r"Missing parameters: \['b'\]")
 
 
 def test_validate_missing_params_class():
@@ -256,12 +256,12 @@ def test_validate_missing_params_class():
     with pytest.raises(ValueError) as err:
         validate_params(ExampleClass, [])
 
-    assert err.match("Missing parameters: \['a', 'b'\]")
+    assert err.match(r"Missing parameters: \['a', 'b'\]")
 
     with pytest.raises(ValueError) as err:
         validate_params(ExampleClass, ["a"])
 
-    assert err.match("Missing parameters: \['b'\]")
+    assert err.match(r"Missing parameters: \['b'\]")
 
 
 def test_validate_args_function():
@@ -271,7 +271,7 @@ def test_validate_args_function():
     with pytest.raises(ValueError) as err:
         validate_params(example_function, ["args"])
 
-    assert err.match("\*args not allowed")
+    assert err.match(r"\*args not allowed")
 
 
 def test_validate_args_class():
@@ -282,7 +282,7 @@ def test_validate_args_class():
     with pytest.raises(ValueError) as err:
         validate_params(ExampleClass, ["args"])
 
-    assert err.match("\*args not allowed")
+    assert err.match(r"\*args not allowed")
 
 
 def test_validate_default_function():
@@ -309,7 +309,7 @@ def test_validate_missing_not_default_function():
     with pytest.raises(ValueError) as err:
         validate_params(example_function, [])
 
-    assert err.match("Missing parameters: \['a'\]")
+    assert err.match(r"Missing parameters: \['a'\]")
 
 
 def test_validate_missing_not_default_class():
@@ -320,7 +320,7 @@ def test_validate_missing_not_default_class():
     with pytest.raises(ValueError) as err:
         validate_params(ExampleClass, [])
 
-    assert err.match("Missing parameters: \['a'\]")
+    assert err.match(r"Missing parameters: \['a'\]")
 
 
 def test_validate_kwargs_function():


### PR DESCRIPTION
This fixes some escaping issues in the unit tests.