### PR TITLE
Move RNG to curriculum class property

### DIFF
--- a/examples/curriculums/condensed_curriculum.py
+++ b/examples/curriculums/condensed_curriculum.py
@@ -14,31 +14,86 @@ class ExampleCondensed(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
         task_variants = [
-            EpisodicTaskVariant(Task1VariantA, num_episodes=10),
-            EpisodicTaskVariant(Task2, num_episodes=10),
-            EpisodicTaskVariant(Task3Variant1, num_episodes=10),
-            EpisodicTaskVariant(Task4, num_episodes=10),
-            EpisodicTaskVariant(Task1VariantB, num_episodes=10, params={"a": 0.1}),
-            EpisodicTaskVariant(Task2, num_episodes=10, params={"b": 0.2}),
-            EpisodicTaskVariant(Task3Variant2, num_episodes=10, params={"c": 0.3}),
-            EpisodicTaskVariant(Task4, num_episodes=10, params={"d": 0.4}),
+            EpisodicTaskVariant(
+                Task1VariantA,
+                num_episodes=10,
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task2, num_episodes=10, rng_seed=self.rng.bit_generator.random_raw()
+            ),
+            EpisodicTaskVariant(
+                Task3Variant1,
+                num_episodes=10,
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task4, num_episodes=10, rng_seed=self.rng.bit_generator.random_raw()
+            ),
+            EpisodicTaskVariant(
+                Task1VariantB,
+                num_episodes=10,
+                params={"a": 0.1},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task2,
+                num_episodes=10,
+                params={"b": 0.2},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task3Variant2,
+                num_episodes=10,
+                params={"c": 0.3},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task4,
+                num_episodes=10,
+                params={"d": 0.4},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
         ]
-        rng = np.random.default_rng(self.rng_seed)
-        rng.shuffle(task_variants)
+        self.rng.shuffle(task_variants)
         for task_variant in task_variants:
             yield simple_learn_block([task_variant])
 
     def eval_block(self) -> AbstractEvalBlock[AbstractRLTaskVariant]:
         return simple_eval_block(
             [
-                EpisodicTaskVariant(Task1VariantA, num_episodes=1),
-                EpisodicTaskVariant(Task2, num_episodes=1),
-                EpisodicTaskVariant(Task3Variant1, num_episodes=1),
-                EpisodicTaskVariant(Task4, num_episodes=1),
-                EpisodicTaskVariant(Task1VariantB, num_episodes=1, params={"a": 0.1}),
-                EpisodicTaskVariant(Task2, num_episodes=1, params={"b": 0.2}),
-                EpisodicTaskVariant(Task3Variant2, num_episodes=1, params={"c": 0.3}),
-                EpisodicTaskVariant(Task4, num_episodes=1, params={"d": 0.4}),
+                EpisodicTaskVariant(
+                    Task1VariantA, num_episodes=1, rng_seed=self.eval_rng_seed
+                ),
+                EpisodicTaskVariant(Task2, num_episodes=1, rng_seed=self.eval_rng_seed),
+                EpisodicTaskVariant(
+                    Task3Variant1, num_episodes=1, rng_seed=self.eval_rng_seed
+                ),
+                EpisodicTaskVariant(Task4, num_episodes=1, rng_seed=self.eval_rng_seed),
+                EpisodicTaskVariant(
+                    Task1VariantB,
+                    num_episodes=1,
+                    params={"a": 0.1},
+                    rng_seed=self.eval_rng_seed,
+                ),
+                EpisodicTaskVariant(
+                    Task2,
+                    num_episodes=1,
+                    params={"b": 0.2},
+                    rng_seed=self.eval_rng_seed,
+                ),
+                EpisodicTaskVariant(
+                    Task3Variant2,
+                    num_episodes=1,
+                    params={"c": 0.3},
+                    rng_seed=self.eval_rng_seed,
+                ),
+                EpisodicTaskVariant(
+                    Task4,
+                    num_episodes=1,
+                    params={"d": 0.4},
+                    rng_seed=self.eval_rng_seed,
+                ),
             ]
         )
 

--- a/examples/curriculums/dispersed_curriculum.py
+++ b/examples/curriculums/dispersed_curriculum.py
@@ -18,18 +18,49 @@ class ExampleDispersed(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
         task_variants = [
-            EpisodicTaskVariant(Task1VariantA, num_episodes=10),
-            EpisodicTaskVariant(Task2, num_episodes=10),
-            EpisodicTaskVariant(Task3Variant1, num_episodes=10),
-            EpisodicTaskVariant(Task4, num_episodes=10),
-            EpisodicTaskVariant(Task1VariantB, num_episodes=10, params={"a": 0.1}),
-            EpisodicTaskVariant(Task2, num_episodes=10, params={"b": 0.2}),
-            EpisodicTaskVariant(Task3Variant2, num_episodes=10, params={"c": 0.3}),
-            EpisodicTaskVariant(Task4, num_episodes=10, params={"d": 0.4}),
+            EpisodicTaskVariant(
+                Task1VariantA,
+                num_episodes=10,
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task2, num_episodes=10, rng_seed=self.rng.bit_generator.random_raw()
+            ),
+            EpisodicTaskVariant(
+                Task3Variant1,
+                num_episodes=10,
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task4, num_episodes=10, rng_seed=self.rng.bit_generator.random_raw()
+            ),
+            EpisodicTaskVariant(
+                Task1VariantB,
+                num_episodes=10,
+                params={"a": 0.1},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task2,
+                num_episodes=10,
+                params={"b": 0.2},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task3Variant2,
+                num_episodes=10,
+                params={"c": 0.3},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
+            EpisodicTaskVariant(
+                Task4,
+                num_episodes=10,
+                params={"d": 0.4},
+                rng_seed=self.rng.bit_generator.random_raw(),
+            ),
         ]
-        rng = np.random.default_rng(self.rng_seed)
         for i_repetition in range(self.num_repetitions):
-            rng.shuffle(task_variants)
+            self.rng.shuffle(task_variants)
             for task_variant in task_variants:
                 # NOTE: only 1 experience in the learn block
                 yield simple_learn_block([task_variant])
@@ -37,14 +68,38 @@ class ExampleDispersed(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
     def eval_block(self) -> AbstractEvalBlock[AbstractRLTaskVariant]:
         return simple_eval_block(
             [
-                EpisodicTaskVariant(Task1VariantA, num_episodes=1),
-                EpisodicTaskVariant(Task2, num_episodes=1),
-                EpisodicTaskVariant(Task3Variant1, num_episodes=1),
-                EpisodicTaskVariant(Task4, num_episodes=1),
-                EpisodicTaskVariant(Task1VariantB, num_episodes=1, params={"a": 0.1}),
-                EpisodicTaskVariant(Task2, num_episodes=1, params={"b": 0.2}),
-                EpisodicTaskVariant(Task3Variant2, num_episodes=1, params={"c": 0.3}),
-                EpisodicTaskVariant(Task4, num_episodes=1, params={"d": 0.4}),
+                EpisodicTaskVariant(
+                    Task1VariantA, num_episodes=1, rng_seed=self.eval_rng_seed
+                ),
+                EpisodicTaskVariant(Task2, num_episodes=1, rng_seed=self.eval_rng_seed),
+                EpisodicTaskVariant(
+                    Task3Variant1, num_episodes=1, rng_seed=self.eval_rng_seed
+                ),
+                EpisodicTaskVariant(Task4, num_episodes=1, rng_seed=self.eval_rng_seed),
+                EpisodicTaskVariant(
+                    Task1VariantB,
+                    num_episodes=1,
+                    params={"a": 0.1},
+                    rng_seed=self.eval_rng_seed,
+                ),
+                EpisodicTaskVariant(
+                    Task2,
+                    num_episodes=1,
+                    params={"b": 0.2},
+                    rng_seed=self.eval_rng_seed,
+                ),
+                EpisodicTaskVariant(
+                    Task3Variant2,
+                    num_episodes=1,
+                    params={"c": 0.3},
+                    rng_seed=self.eval_rng_seed,
+                ),
+                EpisodicTaskVariant(
+                    Task4,
+                    num_episodes=1,
+                    params={"d": 0.4},
+                    rng_seed=self.eval_rng_seed,
+                ),
             ]
         )
 

--- a/tella/_curriculums/cartpole.py
+++ b/tella/_curriculums/cartpole.py
@@ -38,7 +38,6 @@ class SimpleCartPoleCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
             "AbstractEvalBlock[AbstractRLTaskVariant]",
         ]
     ]:
-        rng = np.random.default_rng(self.rng_seed)
         yield simple_learn_block(
             [
                 EpisodicTaskVariant(
@@ -46,7 +45,7 @@ class SimpleCartPoleCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
                     num_episodes=5,
                     task_label="CartPole",
                     variant_label="Default",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 )
             ]
         )
@@ -57,7 +56,7 @@ class SimpleCartPoleCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
                     num_episodes=1,
                     task_label="CartPole",
                     variant_label="Default",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 )
             ]
         )
@@ -72,7 +71,6 @@ class CartPole1000Curriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
             "AbstractEvalBlock[AbstractRLTaskVariant]",
         ]
     ]:
-        rng = np.random.default_rng(self.rng_seed)
         for _ in range(10):
             yield simple_learn_block(
                 [
@@ -81,13 +79,12 @@ class CartPole1000Curriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
                         num_episodes=100,
                         task_label="CartPole",
                         variant_label="Default",
-                        rng_seed=rng.bit_generator.random_raw(),
+                        rng_seed=self.rng.bit_generator.random_raw(),
                     )
                 ]
             )
 
     def eval_block(self) -> AbstractEvalBlock[AbstractRLTaskVariant]:
-        rng = np.random.default_rng(self.rng_seed)
         return simple_eval_block(
             [
                 EpisodicTaskVariant(
@@ -95,7 +92,7 @@ class CartPole1000Curriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
                     num_episodes=10,
                     task_label="CartPole",
                     variant_label="Default",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.eval_rng_seed,
                 )
             ]
         )

--- a/tella/_curriculums/minigrid/m21.py
+++ b/tella/_curriculums/minigrid/m21.py
@@ -228,14 +228,13 @@ TASKS = [
 
 class _MiniGridCurriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant]):
     def eval_block(self) -> AbstractEvalBlock[AbstractRLTaskVariant]:
-        rng = np.random.default_rng(self.rng_seed)
         return simple_eval_block(
             EpisodicTaskVariant(
                 cls,
                 task_label=task_label,
                 variant_label=variant_label,
                 num_episodes=100,
-                rng_seed=rng.bit_generator.random_raw(),
+                rng_seed=self.eval_rng_seed,
             )
             for cls, task_label, variant_label in TASKS
         )
@@ -245,8 +244,7 @@ class MiniGridCondensed(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
-        for cls, task_label, variant_label in rng.permutation(TASKS):
+        for cls, task_label, variant_label in self.rng.permutation(TASKS):
             yield LearnBlock(
                 [
                     TaskBlock(
@@ -257,7 +255,7 @@ class MiniGridCondensed(_MiniGridCurriculum):
                                 task_label=task_label,
                                 variant_label=variant_label,
                                 num_episodes=1000,
-                                rng_seed=rng.bit_generator.random_raw(),
+                                rng_seed=self.rng.bit_generator.random_raw(),
                             )
                         ],
                     )
@@ -273,10 +271,8 @@ class MiniGridDispersed(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         for _ in range(self.num_repetitions):
-            rng = np.random.default_rng(self.rng_seed)
-            for cls, task_label, variant_label in rng.permutation(TASKS):
+            for cls, task_label, variant_label in self.rng.permutation(TASKS):
                 yield LearnBlock(
                     [
                         TaskBlock(
@@ -287,7 +283,7 @@ class MiniGridDispersed(_MiniGridCurriculum):
                                     task_label=task_label,
                                     variant_label=variant_label,
                                     num_episodes=1000 // self.num_repetitions,
-                                    rng_seed=rng.bit_generator.random_raw(),
+                                    rng_seed=self.rng.bit_generator.random_raw(),
                                 )
                             ],
                         )
@@ -299,7 +295,6 @@ class MiniGridSimpleCrossingS9N1(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -310,7 +305,7 @@ class MiniGridSimpleCrossingS9N1(_MiniGridCurriculum):
                             task_label="SimpleCrossing",
                             variant_label="S9N1",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -322,7 +317,6 @@ class MiniGridSimpleCrossingS9N2(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -333,7 +327,7 @@ class MiniGridSimpleCrossingS9N2(_MiniGridCurriculum):
                             task_label="SimpleCrossing",
                             variant_label="S9N2",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -345,7 +339,6 @@ class MiniGridSimpleCrossingS9N3(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -356,7 +349,7 @@ class MiniGridSimpleCrossingS9N3(_MiniGridCurriculum):
                             task_label="SimpleCrossing",
                             variant_label="S9N3",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -368,7 +361,6 @@ class MiniGridDistShiftR2(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -379,7 +371,7 @@ class MiniGridDistShiftR2(_MiniGridCurriculum):
                             task_label="DistShift",
                             variant_label="R2",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -391,7 +383,6 @@ class MiniGridDistShiftR5(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -402,7 +393,7 @@ class MiniGridDistShiftR5(_MiniGridCurriculum):
                             task_label="DistShift",
                             variant_label="R5",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -414,7 +405,6 @@ class MiniGridDistShiftR3(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -425,7 +415,7 @@ class MiniGridDistShiftR3(_MiniGridCurriculum):
                             task_label="DistShift",
                             variant_label="R3",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -437,7 +427,6 @@ class MiniGridDynObstaclesS5N2(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -448,7 +437,7 @@ class MiniGridDynObstaclesS5N2(_MiniGridCurriculum):
                             task_label="DynObstacles",
                             variant_label="S5N2",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -460,7 +449,6 @@ class MiniGridDynObstaclesS6N3(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -471,7 +459,7 @@ class MiniGridDynObstaclesS6N3(_MiniGridCurriculum):
                             task_label="DynObstacles",
                             variant_label="S6N3",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -483,7 +471,6 @@ class MiniGridDynObstaclesS8N4(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -494,7 +481,7 @@ class MiniGridDynObstaclesS8N4(_MiniGridCurriculum):
                             task_label="DynObstacles",
                             variant_label="S8N4",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -506,7 +493,6 @@ class MiniGridCustomFetchS5T1N2(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -517,7 +503,7 @@ class MiniGridCustomFetchS5T1N2(_MiniGridCurriculum):
                             task_label="CustomFetch",
                             variant_label="S5T1N2",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -529,7 +515,6 @@ class MiniGridCustomFetchS8T1N2(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -540,7 +525,7 @@ class MiniGridCustomFetchS8T1N2(_MiniGridCurriculum):
                             task_label="CustomFetch",
                             variant_label="S8T1N2",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -552,7 +537,6 @@ class MiniGridCustomFetchS16T2N4(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -563,7 +547,7 @@ class MiniGridCustomFetchS16T2N4(_MiniGridCurriculum):
                             task_label="CustomFetch",
                             variant_label="S16T2N4",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -575,7 +559,6 @@ class MiniGridCustomUnlockS5(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -586,7 +569,7 @@ class MiniGridCustomUnlockS5(_MiniGridCurriculum):
                             task_label="CustomUnlock",
                             variant_label="S5",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -598,7 +581,6 @@ class MiniGridCustomUnlockS7(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -609,7 +591,7 @@ class MiniGridCustomUnlockS7(_MiniGridCurriculum):
                             task_label="CustomUnlock",
                             variant_label="S7",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -621,7 +603,6 @@ class MiniGridCustomUnlockS9(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -632,7 +613,7 @@ class MiniGridCustomUnlockS9(_MiniGridCurriculum):
                             task_label="CustomUnlock",
                             variant_label="S9",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -644,7 +625,6 @@ class MiniGridDoorKeyS5(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -655,7 +635,7 @@ class MiniGridDoorKeyS5(_MiniGridCurriculum):
                             task_label="DoorKey",
                             variant_label="S5",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -667,7 +647,6 @@ class MiniGridDoorKeyS6(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -678,7 +657,7 @@ class MiniGridDoorKeyS6(_MiniGridCurriculum):
                             task_label="DoorKey",
                             variant_label="S6",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )
@@ -690,7 +669,6 @@ class MiniGridDoorKeyS8(_MiniGridCurriculum):
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield LearnBlock(
             [
                 TaskBlock(
@@ -701,7 +679,7 @@ class MiniGridDoorKeyS8(_MiniGridCurriculum):
                             task_label="DoorKey",
                             variant_label="S8",
                             num_episodes=1000,
-                            rng_seed=rng.bit_generator.random_raw(),
+                            rng_seed=self.rng.bit_generator.random_raw(),
                         )
                     ],
                 )

--- a/tella/_curriculums/minigrid/simple.py
+++ b/tella/_curriculums/minigrid/simple.py
@@ -72,8 +72,7 @@ class SimpleMiniGridCurriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant])
     def learn_blocks(
         self,
     ) -> typing.Iterable[AbstractLearnBlock[AbstractRLTaskVariant]]:
-        rng = np.random.default_rng(self.rng_seed)
-        for cls, task_label, variant_label in rng.permutation(TASKS):
+        for cls, task_label, variant_label in self.rng.permutation(TASKS):
             yield LearnBlock(
                 [
                     TaskBlock(
@@ -84,7 +83,7 @@ class SimpleMiniGridCurriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant])
                                 task_label=task_label,
                                 variant_label=variant_label,
                                 num_episodes=5,
-                                rng_seed=rng.bit_generator.random_raw(),
+                                rng_seed=self.rng.bit_generator.random_raw(),
                             )
                         ],
                     )
@@ -92,14 +91,13 @@ class SimpleMiniGridCurriculum(InterleavedEvalCurriculum[AbstractRLTaskVariant])
             )
 
     def eval_block(self) -> AbstractEvalBlock[AbstractRLTaskVariant]:
-        rng = np.random.default_rng(self.rng_seed)
         return simple_eval_block(
             EpisodicTaskVariant(
                 cls,
                 task_label=task_label,
                 variant_label=variant_label,
                 num_episodes=5,
-                rng_seed=rng.bit_generator.random_raw(),
+                rng_seed=self.eval_rng_seed,
             )
-            for cls, task_label, variant_label in rng.permutation(TASKS)
+            for cls, task_label, variant_label in TASKS
         )

--- a/tests/simple_curriculum.py
+++ b/tests/simple_curriculum.py
@@ -15,19 +15,18 @@ class SimpleRLCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
             "AbstractEvalBlock[AbstractRLTaskVariant]",
         ]
     ]:
-        rng = np.random.default_rng(self.rng_seed)
         yield simple_learn_block(
             [
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 ),
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
                     variant_label="Variant1",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 ),
             ]
         )
@@ -36,7 +35,7 @@ class SimpleRLCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 )
             ]
         )

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -153,15 +153,14 @@ class ShuffledCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
             "AbstractEvalBlock[AbstractRLTaskVariant]",
         ]
     ]:
-        rng = np.random.default_rng(self.rng_seed)
-        for n in rng.permutation(100):
+        for n in self.rng.permutation(100):
             yield simple_learn_block(
                 [
                     EpisodicTaskVariant(
                         CartPoleEnv,
                         num_episodes=1,
                         task_label=f"Task{n}",
-                        rng_seed=rng.bit_generator.random_raw(),
+                        rng_seed=self.rng.bit_generator.random_raw(),
                     )
                 ]
             )
@@ -171,7 +170,7 @@ class ShuffledCurriculum(AbstractCurriculum[AbstractRLTaskVariant]):
                     CartPoleEnv,
                     num_episodes=1,
                     task_label="Task0",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 )
             ]
         )
@@ -201,7 +200,6 @@ def test_curriculum_diff_rng_seed():
 
 def test_curriculum_rng_seed():
     curriculum = ShuffledCurriculum(0)
-
     first_call_tasks = [
         (variant.task_label, variant.variant_label)
         for block in curriculum.learn_blocks_and_eval_blocks()
@@ -209,6 +207,7 @@ def test_curriculum_rng_seed():
         for variant in task.task_variants()
     ]
 
+    curriculum = ShuffledCurriculum(0)
     second_call_tasks = [
         (variant.task_label, variant.variant_label)
         for block in curriculum.learn_blocks_and_eval_blocks()
@@ -228,37 +227,34 @@ class ShuffledInterleavedCurriculum(InterleavedEvalCurriculum[AbstractRLTaskVari
             "AbstractEvalBlock[AbstractRLTaskVariant]",
         ]
     ]:
-        rng = np.random.default_rng(self.rng_seed)
-        for n in rng.permutation(10):
+        for n in self.rng.permutation(10):
             yield simple_learn_block(
                 [
                     EpisodicTaskVariant(
                         CartPoleEnv,
                         num_episodes=1,
                         task_label=f"Task{n}",
-                        rng_seed=rng.bit_generator.random_raw(),
+                        rng_seed=self.rng.bit_generator.random_raw(),
                     )
                 ]
             )
 
     def eval_block(self) -> AbstractEvalBlock[TaskVariantType]:
-        rng = np.random.default_rng(self.rng_seed)
         return simple_eval_block(
             [
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
                     task_label=f"Task{n}",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.eval_rng_seed,
                 )
-                for n in rng.permutation(10)
+                for n in range(10)
             ]
         )
 
 
 def test_interleaved_rng_seed():
     curriculum = ShuffledInterleavedCurriculum(0)
-
     first_call_tasks = [
         (variant.task_label, variant.variant_label)
         for block in curriculum.learn_blocks_and_eval_blocks()
@@ -266,6 +262,7 @@ def test_interleaved_rng_seed():
         for variant in task.task_variants()
     ]
 
+    curriculum = ShuffledInterleavedCurriculum(0)
     second_call_tasks = [
         (variant.task_label, variant.variant_label)
         for block in curriculum.learn_blocks_and_eval_blocks()
@@ -278,14 +275,13 @@ def test_interleaved_rng_seed():
 
 class SampleInterleavedCurriculum(InterleavedEvalCurriculum):
     def learn_blocks(self) -> typing.Iterable[AbstractLearnBlock[TaskVariantType]]:
-        rng = np.random.default_rng(self.rng_seed)
         yield simple_learn_block(
             [
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
                     task_label="Task1",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 ),
             ]
         )
@@ -295,7 +291,7 @@ class SampleInterleavedCurriculum(InterleavedEvalCurriculum):
                     CartPoleEnv,
                     num_episodes=1,
                     task_label="Task2",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 ),
             ]
         )
@@ -305,26 +301,25 @@ class SampleInterleavedCurriculum(InterleavedEvalCurriculum):
                     CartPoleEnv,
                     num_episodes=1,
                     task_label="Task3",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.rng.bit_generator.random_raw(),
                 )
             ]
         )
 
     def eval_block(self) -> AbstractEvalBlock[TaskVariantType]:
-        rng = np.random.default_rng(self.rng_seed)
         return simple_eval_block(
             [
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
                     task_label="Task1",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.eval_rng_seed,
                 ),
                 EpisodicTaskVariant(
                     CartPoleEnv,
                     num_episodes=1,
                     task_label="Task1",
-                    rng_seed=rng.bit_generator.random_raw(),
+                    rng_seed=self.eval_rng_seed + 1,
                 ),
             ]
         )


### PR DESCRIPTION
As discussed in #168, we could move RNG to a curriculum class property to cut down on required code per curriculum instance.

Additionally, `InterleavedEvalCurriculum` should now have all identical eval blocks.