### PR TITLE
Alternate unit test for vector env masking

### DIFF
--- a/tests/test_rl_task_variants.py
+++ b/tests/test_rl_task_variants.py
@@ -2,6 +2,7 @@ import math
 import pytest
 import typing
 import gym
+from gym.envs.classic_control import CartPoleEnv
 from tella.curriculum import EpisodicTaskVariant, _where
 
 
@@ -222,7 +223,31 @@ def test_single_env_mask():
 
 
 @pytest.mark.parametrize("num_episodes", [1, 3, 5])
-def test_vec_env_mask(num_episodes: int):
+def test_vec_cartpole_env_mask(num_episodes: int):
+    num_envs = 3
+    task_variant = EpisodicTaskVariant(
+        CartPoleEnv,
+        num_episodes=num_episodes,
+        rng_seed=0,
+    )
+    task_variant.set_num_envs(num_envs)
+    transitions = list(task_variant.generate(choose_action_zero))
+
+    episode_id = [i for i in range(num_envs)]
+    next_episode_id = num_envs
+    for batch in transitions:
+        for n, transition in enumerate(batch):
+            if transition is not None:
+                obs, action, reward, done, next_obs = transition
+                if done:
+                    episode_id[n] = next_episode_id
+                    next_episode_id += 1
+            else:
+                assert episode_id[n] >= num_episodes
+
+
+@pytest.mark.parametrize("num_episodes", [1, 3, 5])
+def test_vec_dummy_env_mask(num_episodes: int):
     num_envs = 3
     task_rng_seed = 0
     episode_lengths = [4, 6, 7]


### PR DESCRIPTION
Requesting separate review, because the use of rng seed as index is really ugly, but otherwise each episode has the same length, or has an unpredictable length, each of which has been rejected in previous iterations of this test.