### PR TITLE
Resolves #262. Task variants with zero limit will run zero iterations.

### DIFF
--- a/tella/experiment.py
+++ b/tella/experiment.py
@@ -374,7 +374,10 @@ def generate_transitions(
     next_episode_id = episode_ids[-1] + 1
 
     observations = env.reset()
-    continue_task = True
+    if task_variant.num_episodes is not None:
+        continue_task = num_episodes_finished < task_variant.num_episodes
+    else:
+        continue_task = num_steps_finished < task_variant.num_steps
     while continue_task:
         # mask out any environments that have episode id above max episodes or steps above max steps
         if task_variant.num_episodes is not None:


### PR DESCRIPTION
Is there an existing unit test that can be configured to catch this?

Do we even want to permit this configuration?