### PR TITLE
Resolves #176. Readable CLI help

### DIFF
--- a/tella/cli.py
+++ b/tella/cli.py
@@ -154,6 +154,7 @@ def _build_parser(require_curriculum: bool) -> argparse.ArgumentParser:
             type=str,
             choices=curriculum_registry,
             metavar="CURRICULUM_NAME",
-            help="Curriculum name for registry lookup. Registered options are: " + ", ".join(curriculum_registry),
+            help="Curriculum name for registry lookup. Registered options are: "
+            + ", ".join(curriculum_registry),
         )
     return parser


### PR DESCRIPTION
With this change to the CLI argparse, help prints as:

```
  --curriculum CURRICULUM_NAME
                        Curriculum name for registry lookup. Registered options are: SimpleCartPole,
                        CartPole-1000, SimpleMiniGrid, SimpleStepMiniGrid, MiniGridCondensed, MiniGridDispersed,
                        MiniGridSimpleCrossingS9N1, MiniGridSimpleCrossingS9N2, MiniGridSimpleCrossingS9N3,
                        MiniGridDistShiftR2, MiniGridDistShiftR5, MiniGridDistShiftR3, MiniGridDynObstaclesS6N1,
                        MiniGridDynObstaclesS8N2, MiniGridDynObstaclesS10N3, MiniGridCustomFetchS5T1N2,
                        MiniGridCustomFetchS8T1N2, MiniGridCustomFetchS10T2N4, MiniGridCustomUnlockS5,
                        MiniGridCustomUnlockS7, MiniGridCustomUnlockS9, MiniGridDoorKeyS5, MiniGridDoorKeyS6,
                        MiniGridDoorKeyS7 (default: None)
```